### PR TITLE
Fix compatibily with minitest.

### DIFF
--- a/ruby/test/unit/tc_field_symbol.rb
+++ b/ruby/test/unit/tc_field_symbol.rb
@@ -21,6 +21,6 @@ class FieldSymbolTest < Test::Unit::TestCase
       assert_equal(field_type, :sym.__send__(field_type).type)
     end
 
-    assert(:string, :sym.integer.byte.float.string.type)
+    assert(:string, :sym.integer.byte.float.string.type.to_s)
   end
 end


### PR DESCRIPTION
Fixes the first issue mentioned in #2. Minitest accepts just strings and procs while test-unit was not that picky.
