### PR TITLE
Fixed IndexReader offset issue for large files

### DIFF
--- a/c/src/index.c
+++ b/c/src/index.c
@@ -1649,7 +1649,7 @@ LazyDoc *fr_get_lazy_doc(FieldsReader *fr, int doc_num)
     for (i = 0; i < stored_cnt; i++) {
         LazyDocField *lazy_df = lazy_doc->fields[i];
         const int data_cnt = lazy_df->size;
-        const int start = is_pos(fdt_in);
+        const off_t start = is_pos(fdt_in);
         for (j = 0; j < data_cnt; j++) {
             lazy_df->data[j].start += start;
         }

--- a/ruby/lib/ferret/version.rb
+++ b/ruby/lib/ferret/version.rb
@@ -1,3 +1,3 @@
 module Ferret
-  VERSION = '0.11.8.4'
+  VERSION = '0.11.8.5'
 end


### PR DESCRIPTION
Hey,

I fixed the problem with loading stored data from an index when the index size is over 2GB. Previously searching was working fine, but loading data from the index was failing with the following error:

IOError: IO Error occured at <except.c>:75 in frt_xraise
Error occured in fs_store.c:307 - fsi_seek_i
seeking pos -600332448: <Invalid argument>

from (irb):7:in `load'
from (irb):7
from :0

I bumped the version to 0.11.8.5.

Please let me know if you have any questions.

Thanks,
Michal
